### PR TITLE
fix: install ODBC Driver 18 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/nightly_etl.yml
+++ b/.github/workflows/nightly_etl.yml
@@ -25,6 +25,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.lock
         
+    - name: Install SQL Server ODBC Driver
+      run: |
+        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+        curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+        sudo apt-get update
+        sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+        sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18
+        echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
+        
     - name: Run ETL process
       env:
         # Use GitHub secrets for all credentials


### PR DESCRIPTION
- Add missing installation steps for MS SQL Server ODBC Driver 18 on Ubuntu runner
- Fix the 'Driver not found' error in GitHub Actions workflow
- Ensure GitHub Actions environment matches local development