### PR TITLE
feat: updated sql logic for when run closes

### DIFF
--- a/redshift/adjustment_items.sql
+++ b/redshift/adjustment_items.sql
@@ -36,3 +36,5 @@ INNER JOIN bridge."public"."agency" agency ON agency.agency_key = adj.agency_key
 INNER JOIN bridge."public"."supplier" supplier ON supplier.supplier_key = adj.supplier_key
 INNER JOIN bridge."public"."commission_adjustment_type" adj_type ON adj_type.commission_adjustment_type_key = adj.commission_adjustment_type_key
 WHERE run.run_is_closed = false
+   OR (run.run_is_closed = true AND run.run_date_closed >= DATEADD(day, -4, CURRENT_DATE))
+   

--- a/redshift/commission_item.sql
+++ b/redshift/commission_item.sql
@@ -62,3 +62,4 @@ INNER JOIN bridge."public"."rep" rep ON rep.rep_key = ci.rep_key
 INNER JOIN bridge."public"."agency" agency ON rep.rep_agency_id = agency.agency_id
 INNER JOIN bridge."public"."product" product ON product.product_key = ci.product_key
 WHERE run.run_is_closed = false
+   OR (run.run_is_closed = true AND run.run_date_closed >= DATEADD(day, -4, CURRENT_DATE))

--- a/redshift/referral_items.sql
+++ b/redshift/referral_items.sql
@@ -68,3 +68,4 @@ INNER JOIN bridge."public"."rep" rep ON rep.rep_key = ci.rep_key
 INNER JOIN bridge."public"."account" acct ON acct.account_key = rp.account_key
 INNER JOIN bridge."public"."product" product ON product.product_key = rp.product_key
 WHERE run.run_is_closed = false
+   OR (run.run_is_closed = true AND run.run_date_closed >= DATEADD(day, -4, CURRENT_DATE))


### PR DESCRIPTION
Fixed a gap in logic where the run can close before payment is sent to agents. The fix allows the preview to remain live for 4 days after the run closes. Should be enough time till payment and for the next run to open. 